### PR TITLE
Mytours web migration

### DIFF
--- a/definitions/payload.proto
+++ b/definitions/payload.proto
@@ -73,4 +73,5 @@ message Payload {
   repeated Partner partners = 13;
   repeated Account accounts = 14;
   repeated External external = 15;
+  int32 jwt_token_version = 16;
 }

--- a/definitions/payload.proto
+++ b/definitions/payload.proto
@@ -38,6 +38,8 @@ message Payload {
     // string jti = 7;
     reserved 4 to 9;
     repeated Role roles = 10;
+    string name = 11;
+    bool auto_approve = 12;
   }
 
   message External {

--- a/definitions/payload.proto
+++ b/definitions/payload.proto
@@ -60,14 +60,12 @@ message Payload {
   // string iss = 1;
   reserved 1;
   string sub = 2;
-  reserved 3;
   // string aud = 3;
-  int32 exp = 4;
-  reserved 5;
+  // int32 exp = 4;
   // int32 nbf = 5;
-  int32 iat = 6;
+  // int32 iat = 6;
   // string jti = 7;
-  reserved 7 to 8;
+  reserved 3 to 8;
   string username = 9;
   repeated Role roles = 10;
   string name = 11;

--- a/definitions/payload.proto
+++ b/definitions/payload.proto
@@ -60,12 +60,14 @@ message Payload {
   // string iss = 1;
   reserved 1;
   string sub = 2;
+  reserved 3;
   // string aud = 3;
-  // int32 exp = 4;
+  int32 exp = 4;
+  reserved 5;
   // int32 nbf = 5;
-  // int32 iat = 6;
+  int32 iat = 6;
   // string jti = 7;
-  reserved 3 to 8;
+  reserved 7 to 8;
   string username = 9;
   repeated Role roles = 10;
   string name = 11;

--- a/lib/authentic_jwt/errors.rb
+++ b/lib/authentic_jwt/errors.rb
@@ -1,4 +1,5 @@
 module AuthenticJwt
   class Unauthorized < RuntimeError; end
   class Forbidden < RuntimeError; end
+  class Expired < RuntimeError; end
 end

--- a/lib/authentic_jwt/payload_pb.rb
+++ b/lib/authentic_jwt/payload_pb.rb
@@ -13,6 +13,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     repeated :partners, :message, 13, "AuthenticJwt.Payload.Partner"
     repeated :accounts, :message, 14, "AuthenticJwt.Payload.Account"
     repeated :external, :message, 15, "AuthenticJwt.Payload.External"
+    optional :jwt_token_version, :int32, 16
   end
   add_message "AuthenticJwt.Payload.Partner" do
     optional :aud, :string, 3

--- a/lib/authentic_jwt/payload_pb.rb
+++ b/lib/authentic_jwt/payload_pb.rb
@@ -6,8 +6,6 @@ require 'google/protobuf'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "AuthenticJwt.Payload" do
     optional :sub, :string, 2
-    optional :exp, :int32, 4
-    optional :iat, :int32, 6
     optional :username, :string, 9
     repeated :roles, :enum, 10, "AuthenticJwt.Payload.Role"
     optional :name, :string, 11

--- a/lib/authentic_jwt/payload_pb.rb
+++ b/lib/authentic_jwt/payload_pb.rb
@@ -21,6 +21,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "AuthenticJwt.Payload.Account" do
     optional :aud, :string, 3
     repeated :roles, :enum, 10, "AuthenticJwt.Payload.Role"
+    optional :name, :string, 11
+    optional :auto_approve, :bool, 12
   end
   add_message "AuthenticJwt.Payload.External" do
     optional :iss, :string, 1

--- a/lib/authentic_jwt/payload_pb.rb
+++ b/lib/authentic_jwt/payload_pb.rb
@@ -6,6 +6,8 @@ require 'google/protobuf'
 Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "AuthenticJwt.Payload" do
     optional :sub, :string, 2
+    optional :exp, :int32, 4
+    optional :iat, :int32, 6
     optional :username, :string, 9
     repeated :roles, :enum, 10, "AuthenticJwt.Payload.Role"
     optional :name, :string, 11

--- a/lib/authentic_jwt/validator.rb
+++ b/lib/authentic_jwt/validator.rb
@@ -48,6 +48,8 @@ module AuthenticJwt
       rescue JWT::DecodeError => error
         if error.message =~ /Signature verification raised/
           raise Unauthorized, "JWT does not match signature"
+        elsif error.message =~ /Signature has expired/
+          raise Expired, "JWT has expired"
         else
           raise Unauthorized, "Bearer token is not a valid JWT"
         end


### PR DESCRIPTION
This PR adds a couple of new fields to the token, as well as jwt_token_version which allows us to detect if the data inside the token is stale when used with the authentic-auth endpoint that returns the current jwt_token_version value.

Also, I've added handing for the "Signature has expired" error message when decoding tokens, so this allows curtis to add handling for this exception. Handing for this is already in mytours-web. Once this handling has been implemented and deployed, then we can add the expiry time to the token in a new PR which will allow this exception to be raised.